### PR TITLE
Allow php:^8.0, because the possibility of a BC break is not present …

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,10 +11,11 @@
         }
     ],
     "require": {
-        "php": "^7.2 || ~8.0.0 || ~8.1.0 || ~8.2.0"
+        "php": "^7.2 || ^8.0"
     },
     "require-dev": {
         "ext-simplexml": "*",
+        "psr/log": "^1",
         "squizlabs/php_codesniffer": "^3.7",
         "vimeo/psalm": "^5",
         "weirdan/codeception-psalm-module": "^0.14.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cf59d2a67608c2bcdca0f09e0e02fbf5",
+    "content-hash": "8c843295438a0840dbe3a5aaad7fb1a2",
     "packages": [],
     "packages-dev": [
         {
@@ -5111,8 +5111,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.2 || ~8.0.0 || ~8.1.0 || ~8.2.0",
-        "ext-simplexml": "*"
+        "php": "^7.2 || ^8.0"
     },
     "platform-dev": {
         "ext-simplexml": "*"


### PR DESCRIPTION
…only with interfaces