### PR TITLE
[v3] Missing return void

### DIFF
--- a/stubs-for-exception/LoggerInterface.phpstub
+++ b/stubs-for-exception/LoggerInterface.phpstub
@@ -28,7 +28,7 @@ interface LoggerInterface
      *
      * @return void
      */
-    public function emergency(string|\Stringable $message, array $context = []);
+    public function emergency(string|\Stringable $message, array $context = []): void;
 
     /**
      * Action must be taken immediately.
@@ -41,7 +41,7 @@ interface LoggerInterface
      *
      * @return void
      */
-    public function alert(string|\Stringable $message, array $context = []);
+    public function alert(string|\Stringable $message, array $context = []): void;
 
     /**
      * Critical conditions.
@@ -53,7 +53,7 @@ interface LoggerInterface
      *
      * @return void
      */
-    public function critical(string|\Stringable $message, array $context = []);
+    public function critical(string|\Stringable $message, array $context = []): void;
 
     /**
      * Runtime errors that do not require immediate action but should typically
@@ -64,7 +64,7 @@ interface LoggerInterface
      *
      * @return void
      */
-    public function error(string|\Stringable $message, array $context = []);
+    public function error(string|\Stringable $message, array $context = []): void;
 
     /**
      * Exceptional occurrences that are not errors.
@@ -77,7 +77,7 @@ interface LoggerInterface
      *
      * @return void
      */
-    public function warning(string|\Stringable $message, array $context = []);
+    public function warning(string|\Stringable $message, array $context = []): void;
 
     /**
      * Normal but significant events.
@@ -87,7 +87,7 @@ interface LoggerInterface
      *
      * @return void
      */
-    public function notice(string|\Stringable $message, array $context = []);
+    public function notice(string|\Stringable $message, array $context = []): void;
 
     /**
      * Interesting events.
@@ -99,7 +99,7 @@ interface LoggerInterface
      *
      * @return void
      */
-    public function info(string|\Stringable $message, array $context = []);
+    public function info(string|\Stringable $message, array $context = []): void;
 
     /**
      * Detailed debug information.
@@ -109,7 +109,7 @@ interface LoggerInterface
      *
      * @return void
      */
-    public function debug(string|\Stringable $message, array $context = []);
+    public function debug(string|\Stringable $message, array $context = []): void;
 
     /**
      * Logs with an arbitrary level.
@@ -122,5 +122,5 @@ interface LoggerInterface
      *
      * @throws \Psr\Log\InvalidArgumentException
      */
-    public function log($level, string|\Stringable $message, array $context = []);
+    public function log($level, string|\Stringable $message, array $context = []): void;
 }

--- a/stubs-for-throwable/LoggerInterface.phpstub
+++ b/stubs-for-throwable/LoggerInterface.phpstub
@@ -28,7 +28,7 @@ interface LoggerInterface
      *
      * @return void
      */
-    public function emergency(string|\Stringable $message, array $context = []);
+    public function emergency(string|\Stringable $message, array $context = []): void;
 
     /**
      * Action must be taken immediately.
@@ -41,7 +41,7 @@ interface LoggerInterface
      *
      * @return void
      */
-    public function alert(string|\Stringable $message, array $context = []);
+    public function alert(string|\Stringable $message, array $context = []): void;
 
     /**
      * Critical conditions.
@@ -53,7 +53,7 @@ interface LoggerInterface
      *
      * @return void
      */
-    public function critical(string|\Stringable $message, array $context = []);
+    public function critical(string|\Stringable $message, array $context = []): void;
 
     /**
      * Runtime errors that do not require immediate action but should typically
@@ -64,7 +64,7 @@ interface LoggerInterface
      *
      * @return void
      */
-    public function error(string|\Stringable $message, array $context = []);
+    public function error(string|\Stringable $message, array $context = []): void;
 
     /**
      * Exceptional occurrences that are not errors.
@@ -77,7 +77,7 @@ interface LoggerInterface
      *
      * @return void
      */
-    public function warning(string|\Stringable $message, array $context = []);
+    public function warning(string|\Stringable $message, array $context = []): void;
 
     /**
      * Normal but significant events.
@@ -87,7 +87,7 @@ interface LoggerInterface
      *
      * @return void
      */
-    public function notice(string|\Stringable $message, array $context = []);
+    public function notice(string|\Stringable $message, array $context = []): void;
 
     /**
      * Interesting events.
@@ -99,7 +99,7 @@ interface LoggerInterface
      *
      * @return void
      */
-    public function info(string|\Stringable $message, array $context = []);
+    public function info(string|\Stringable $message, array $context = []): void;
 
     /**
      * Detailed debug information.
@@ -109,7 +109,7 @@ interface LoggerInterface
      *
      * @return void
      */
-    public function debug(string|\Stringable $message, array $context = []);
+    public function debug(string|\Stringable $message, array $context = []): void;
 
     /**
      * Logs with an arbitrary level.
@@ -122,5 +122,5 @@ interface LoggerInterface
      *
      * @throws \Psr\Log\InvalidArgumentException
      */
-    public function log($level, string|\Stringable $message, array $context = []);
+    public function log($level, string|\Stringable $message, array $context = []): void;
 }


### PR DESCRIPTION
It's my mistake.

psr/log v3 feature is return void. I forget to re-transform for v3...
https://github.com/php-fig/log/blob/3.0.0/src/LoggerInterface.php