### PR TITLE
should be use PHP_80 for v3, lacked of return type

### DIFF
--- a/build/rector-stubs-for-exception.php
+++ b/build/rector-stubs-for-exception.php
@@ -5,7 +5,7 @@ use Rector\Config\RectorConfig;
 return static function (RectorConfig $config): void {
     $services = $config->services();
 
-    $config->phpVersion(\Rector\Core\ValueObject\PhpVersion::PHP_53);
+    $config->phpVersion(\Rector\Core\ValueObject\PhpVersion::PHP_80);
     $services->set(\SfpDev\Stubs\Psr\Log\ExceptionLoggerContextTypeRector::class);
 
     $config->paths([

--- a/build/rector-stubs-for-throwable.php
+++ b/build/rector-stubs-for-throwable.php
@@ -5,7 +5,7 @@ use Rector\Config\RectorConfig;
 return static function (RectorConfig $config): void {
     $services = $config->services();
 
-    $config->phpVersion(\Rector\Core\ValueObject\PhpVersion::PHP_53);
+    $config->phpVersion(\Rector\Core\ValueObject\PhpVersion::PHP_80);
     $services->set(\SfpDev\Stubs\Psr\Log\ThrowableLoggerContextTypeRector::class);
 
     $config->paths([

--- a/stubs-for-exception/LoggerInterface.phpstub
+++ b/stubs-for-exception/LoggerInterface.phpstub
@@ -28,7 +28,7 @@ interface LoggerInterface
      *
      * @return void
      */
-    public function emergency(string|\Stringable $message, array $context = []);
+    public function emergency(string|\Stringable $message, array $context = []): void;
 
     /**
      * Action must be taken immediately.
@@ -41,7 +41,7 @@ interface LoggerInterface
      *
      * @return void
      */
-    public function alert(string|\Stringable $message, array $context = []);
+    public function alert(string|\Stringable $message, array $context = []): void;
 
     /**
      * Critical conditions.
@@ -53,7 +53,7 @@ interface LoggerInterface
      *
      * @return void
      */
-    public function critical(string|\Stringable $message, array $context = []);
+    public function critical(string|\Stringable $message, array $context = []): void;
 
     /**
      * Runtime errors that do not require immediate action but should typically
@@ -64,7 +64,7 @@ interface LoggerInterface
      *
      * @return void
      */
-    public function error(string|\Stringable $message, array $context = []);
+    public function error(string|\Stringable $message, array $context = []): void;
 
     /**
      * Exceptional occurrences that are not errors.
@@ -77,7 +77,7 @@ interface LoggerInterface
      *
      * @return void
      */
-    public function warning(string|\Stringable $message, array $context = []);
+    public function warning(string|\Stringable $message, array $context = []): void;
 
     /**
      * Normal but significant events.
@@ -87,7 +87,7 @@ interface LoggerInterface
      *
      * @return void
      */
-    public function notice(string|\Stringable $message, array $context = []);
+    public function notice(string|\Stringable $message, array $context = []): void;
 
     /**
      * Interesting events.
@@ -99,7 +99,7 @@ interface LoggerInterface
      *
      * @return void
      */
-    public function info(string|\Stringable $message, array $context = []);
+    public function info(string|\Stringable $message, array $context = []): void;
 
     /**
      * Detailed debug information.
@@ -109,7 +109,7 @@ interface LoggerInterface
      *
      * @return void
      */
-    public function debug(string|\Stringable $message, array $context = []);
+    public function debug(string|\Stringable $message, array $context = []): void;
 
     /**
      * Logs with an arbitrary level.
@@ -122,5 +122,5 @@ interface LoggerInterface
      *
      * @throws \Psr\Log\InvalidArgumentException
      */
-    public function log($level, string|\Stringable $message, array $context = []);
+    public function log($level, string|\Stringable $message, array $context = []): void;
 }

--- a/stubs-for-throwable/LoggerInterface.phpstub
+++ b/stubs-for-throwable/LoggerInterface.phpstub
@@ -28,7 +28,7 @@ interface LoggerInterface
      *
      * @return void
      */
-    public function emergency(string|\Stringable $message, array $context = []);
+    public function emergency(string|\Stringable $message, array $context = []): void;
 
     /**
      * Action must be taken immediately.
@@ -41,7 +41,7 @@ interface LoggerInterface
      *
      * @return void
      */
-    public function alert(string|\Stringable $message, array $context = []);
+    public function alert(string|\Stringable $message, array $context = []): void;
 
     /**
      * Critical conditions.
@@ -53,7 +53,7 @@ interface LoggerInterface
      *
      * @return void
      */
-    public function critical(string|\Stringable $message, array $context = []);
+    public function critical(string|\Stringable $message, array $context = []): void;
 
     /**
      * Runtime errors that do not require immediate action but should typically
@@ -64,7 +64,7 @@ interface LoggerInterface
      *
      * @return void
      */
-    public function error(string|\Stringable $message, array $context = []);
+    public function error(string|\Stringable $message, array $context = []): void;
 
     /**
      * Exceptional occurrences that are not errors.
@@ -77,7 +77,7 @@ interface LoggerInterface
      *
      * @return void
      */
-    public function warning(string|\Stringable $message, array $context = []);
+    public function warning(string|\Stringable $message, array $context = []): void;
 
     /**
      * Normal but significant events.
@@ -87,7 +87,7 @@ interface LoggerInterface
      *
      * @return void
      */
-    public function notice(string|\Stringable $message, array $context = []);
+    public function notice(string|\Stringable $message, array $context = []): void;
 
     /**
      * Interesting events.
@@ -99,7 +99,7 @@ interface LoggerInterface
      *
      * @return void
      */
-    public function info(string|\Stringable $message, array $context = []);
+    public function info(string|\Stringable $message, array $context = []): void;
 
     /**
      * Detailed debug information.
@@ -109,7 +109,7 @@ interface LoggerInterface
      *
      * @return void
      */
-    public function debug(string|\Stringable $message, array $context = []);
+    public function debug(string|\Stringable $message, array $context = []): void;
 
     /**
      * Logs with an arbitrary level.
@@ -122,5 +122,5 @@ interface LoggerInterface
      *
      * @throws \Psr\Log\InvalidArgumentException
      */
-    public function log($level, string|\Stringable $message, array $context = []);
+    public function log($level, string|\Stringable $message, array $context = []): void;
 }


### PR DESCRIPTION
In the past, I already did fix of add `return type`  at #18...
But, it was merge into 3.1.x...